### PR TITLE
Return redirect always in logout

### DIFF
--- a/flask_mwoauth/__init__.py
+++ b/flask_mwoauth/__init__.py
@@ -45,7 +45,7 @@ class MWOAuth(object):
             session['mwoauth_username'] = None
             if 'next' in request.args:
                 return redirect(request.args['next'])
-            return "Logged out!"
+            return redirect(self.default_return_to)
 
         @self.bp.route('/login')
         def login():


### PR DESCRIPTION
Pure "logout message" is almost never acceptable in real application. If no 'next' in request.args, use default_return_to.