### PR TITLE
Fix backword compatibility issue

### DIFF
--- a/flask_mwoauth/__init__.py
+++ b/flask_mwoauth/__init__.py
@@ -142,7 +142,10 @@ class MWOAuth(object):
             req = self._prepare_long_request(url=api_url,
                                              api_query=api_query)
             req.send()
-            return req.response.json()
+            if self.return_json:
+                return req.response.json()
+            else:
+                return req.response.text
         else:
             auth1 = OAuth1(
                 self.consumer_token.key,


### PR DESCRIPTION
request() should return json only if requested by the caller