### PR TITLE
Use url_for() in logout

### DIFF
--- a/flask_mwoauth/__init__.py
+++ b/flask_mwoauth/__init__.py
@@ -47,7 +47,7 @@ class MWOAuth(object):
             session['mwoauth_username'] = None
             if 'next' in request.args:
                 return redirect(request.args['next'])
-            return redirect(self.default_return_to)
+            return redirect(url_for(self.default_return_to))
 
         @self.bp.route('/login')
         def login():


### PR DESCRIPTION
flask-mwoauth already uses url_for when parsing
default_return_to parameter, however, only in login workflow
(oauth-callback, if you want me to be precise). In logout workflow,
default_return_to is passed directly to redirect().

That means library users have to choose between throwing fatal
on oauth-callback (because '/' is not parsable in url_for),
or redirecting users to 404 on logout, or introducing
a redirect /index, which will redirect to /,
to bypass this bug.

I understand this is somehow a breaking change, however,
I don't know where to add a feature-flag for it. If the maintainers
have an idea how to improve this change, feel free to comment!